### PR TITLE
Remove HTML line break from notification popup

### DIFF
--- a/src/declarative/pkupdates.cpp
+++ b/src/declarative/pkupdates.cpp
@@ -131,7 +131,7 @@ QString PkUpdates::message() const
         if (extra.isEmpty())
             return msg;
         else
-            return msg + "<br>" + i18n("(including %1)", extra.join(i18n(" and ")));
+            return msg + " " + i18n("(including %1)", extra.join(i18n(" and ")));
     } else if (!isNetworkOnline()) {
         return i18n("Your system is offline");
     } else if (!m_lastCheckSuccessful) {


### PR DESCRIPTION
It looks like HTML line breaks are no longer supported in notifications -- replaced with a space instead to separate additional security/important update count. 

See screenshot: 
<img width="473" alt="screen shot 2018-02-18 at 9 13 42 am" src="https://user-images.githubusercontent.com/1703673/36353180-01e31a8a-1491-11e8-9805-691b6cfacf2a.png">
