### PR TITLE
Added a package deselection config option

### DIFF
--- a/src/plasma/contents/config/main.xml
+++ b/src/plasma/contents/config/main.xml
@@ -21,6 +21,9 @@
     <entry name="check_on_battery" type="Bool">
       <default>false</default>
     </entry>
+    <entry name="deselect_pkgs" type="String">
+      <default></default>
+    </entry>
   </group>
 
 </kcfg>

--- a/src/plasma/contents/ui/ConfigGeneral.qml
+++ b/src/plasma/contents/ui/ConfigGeneral.qml
@@ -33,6 +33,7 @@ Item {
     property alias cfg_monthly: monthly.checked
     property alias cfg_check_on_mobile: mobile.checked
     property alias cfg_check_on_battery: battery.checked
+    property alias cfg_deselect_pkgs: deselect_pkgs.text
 
     Column {
         id: pageColumn
@@ -68,6 +69,14 @@ Item {
         CheckBox {
             id: battery
             text: i18n("Check for updates even when on battery")
+        }
+        Label {
+            text: i18n("Packages or patches to deselect")
+        }
+        TextField {
+            id: deselect_pkgs
+            width: parent.width
+            placeholderText: i18n('[Comma-delimited list of packages to deselect]')
         }
     }
 }

--- a/src/plasma/contents/ui/Full.qml
+++ b/src/plasma/contents/ui/Full.qml
@@ -34,6 +34,8 @@ Item {
     property bool anySelected: checkAnySelected()
     property bool allSelected: checkAllSelected()
     property bool populatePreSelected: true
+    property bool populateDeSelected: false
+    property string deselectPkgs: plasmoid.configuration.deselect_pkgs
 
     Binding {
         target: timestampLabel
@@ -326,14 +328,33 @@ Item {
         return result
     }
 
+    function deselectPackages(name,deselectPkgsList) {
+        var select = populatePreSelected
+        for (var e of deselectPkgsList) {
+            if (e === name) {
+                print("Deselecting " + e)
+                select = populateDeSelected
+                break
+            }
+        }
+        return select
+    }
+
     function populateModel() {
         print("Populating model")
+        print("Packages to deselect: " + deselectPkgs)
+        var deselectPkgsList = deselectPkgs.split(",")
         updatesModel.clear()
         var packages = PkUpdates.packages
         for (var id in packages) {
             if (packages.hasOwnProperty(id)) {
                 var desc = packages[id]
-                updatesModel.append({"selected": populatePreSelected, "id": id, "name": PkUpdates.packageName(id), "desc": desc, "version": PkUpdates.packageVersion(id)})
+                var name = PkUpdates.packageName(id)
+                updatesModel.append({"selected": deselectPackages(name,deselectPkgsList),
+                                     "id": id,
+                                     "name": name,
+                                     "desc": desc,
+                                     "version": PkUpdates.packageVersion(id)})
             }
         }
     }


### PR DESCRIPTION
It may seem redundant but it may be needed in some distros.
For instance, in openSUSE 15.3, PackageKit does not yet support libzypp locks.
It will allow updates to be scheduled without deselecting packages manually.
The deselected packages will still appear in the list and count towards the
updates pending, however.